### PR TITLE
feat(movie-detail): add movie detail feature with new bloc, usecase, …

### DIFF
--- a/lib/core/data/database/daos/movie_dao.dart
+++ b/lib/core/data/database/daos/movie_dao.dart
@@ -40,4 +40,16 @@ class MovieDao {
       return MovieModel.fromMap(maps[i]);
     });
   }
+
+  Future<MovieModel> getMovieById(int id) async {
+    final database = await databaseHelper.database;
+
+    final List<Map<String, dynamic>> maps = await database.query(
+      MovieFields.tableName,
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+
+    return MovieModel.fromMap(maps.first);
+  }
 }

--- a/lib/core/data/database/daos/now_playing_dao.dart
+++ b/lib/core/data/database/daos/now_playing_dao.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_movies/core/data/database/database_helper.dart';
+import 'package:flutter_movies/core/data/database/fields/now_playing_fields.dart';
+import 'package:sqflite/sqflite.dart';
+
+class NowPlayingDao {
+  final DatabaseHelper databaseHelper;
+
+  NowPlayingDao({required this.databaseHelper});
+
+  Future<void> insertNowPlaying(List<int> movieIds) async {
+    final database = await databaseHelper.database;
+    for (var movieId in movieIds) {
+      await database.insert(
+        NowPlayingFields.tableName, 
+        {NowPlayingFields.id: movieId},
+        conflictAlgorithm: ConflictAlgorithm.replace
+      );
+    }
+  }
+
+  Future<void> deleteAll() async {
+    final database = await databaseHelper.database;
+    await database.delete(
+      NowPlayingFields.tableName
+    );
+  }
+
+  Future<List<int>> getNowPlayingIds() async {
+    final database = await databaseHelper.database;
+    final List<Map<String, dynamic>> nowPlayingIds = await database.query(
+      NowPlayingFields.tableName
+    );
+
+    final List<int> movieIds = nowPlayingIds.map((row) => row[NowPlayingFields.id] as int).toList();
+    return movieIds;
+  }
+}

--- a/lib/core/data/database/database_helper.dart
+++ b/lib/core/data/database/database_helper.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_movies/core/data/database/fields/favorite_fields.dart';
 import 'package:flutter_movies/core/data/database/fields/movie_fields.dart';
+import 'package:flutter_movies/core/data/database/fields/now_playing_fields.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
 
@@ -23,8 +24,9 @@ class DatabaseHelper {
       onCreate: (db, version) {
         db.execute(createMoviesTable);
         db.execute(createFavoriteMoviesTable);
+        db.execute(createNowPlayingMoviesTable);
       },
-      version: 1,
+      version: 2,
     );
   }
 }

--- a/lib/core/data/database/fields/now_playing_fields.dart
+++ b/lib/core/data/database/fields/now_playing_fields.dart
@@ -1,0 +1,12 @@
+class NowPlayingFields {
+  static const String tableName = 'now_playing_movies';
+
+  static const String id = 'id';
+}
+
+// SQL statement to create the movies table
+const String createNowPlayingMoviesTable = '''
+  CREATE TABLE ${NowPlayingFields.tableName} (
+    ${NowPlayingFields.id} INTEGER PRIMARY KEY
+  )
+''';

--- a/lib/core/data/datasources/movie_local_datasource.dart
+++ b/lib/core/data/datasources/movie_local_datasource.dart
@@ -6,4 +6,5 @@ abstract class MovieLocalDatasource {
     Future<void> deleteFavorite(int movieId);
     Future<List<int>> getFavoriteIds();
     Future<List<MovieModel>> getFavoriteMovies();
+    Future<MovieModel> getMovieById(int id);
 }

--- a/lib/core/data/datasources/movie_local_datasource_impl.dart
+++ b/lib/core/data/datasources/movie_local_datasource_impl.dart
@@ -41,4 +41,9 @@ class MovieLocalDatasourceImpl implements MovieLocalDatasource {
     return favoriteMovies;
   }
 
+  @override
+  Future<MovieModel> getMovieById(int id) {
+    return movieDao.getMovieById(id);
+  }
+
 }

--- a/lib/core/data/models/movie_model.dart
+++ b/lib/core/data/models/movie_model.dart
@@ -101,7 +101,11 @@ class MovieModel {
       backdropPath: backdropPath ?? '', 
       voteAverage: voteAverage, 
       releaseDate: releaseDate,
-      isFavorite: isFavorite
+      isFavorite: isFavorite,
+      popularity: popularity,
+      voteCount: voteCount,
+      genreIds: genreIds,
+      originalLanguage: originalLanguage
     );
   }
 

--- a/lib/core/data/repositories/movie_repository_impl.dart
+++ b/lib/core/data/repositories/movie_repository_impl.dart
@@ -63,4 +63,10 @@ class MovieRepositoryImpl implements MovieRepository {
   Future<void> deleteFavorite(int movieId) async {
     await localDatasource.deleteFavorite(movieId);
   }
+
+  @override
+  Future<Movie> getMovieById(int movieId) async {
+    final result = await localDatasource.getMovieById(movieId);
+    return result.toDomain(false);
+  }
 }

--- a/lib/core/domain/entities/movie.dart
+++ b/lib/core/domain/entities/movie.dart
@@ -8,6 +8,10 @@ class Movie with ChangeNotifier {
   final String backdropPath;
   final double voteAverage;
   final String releaseDate;
+  final double popularity;
+  final int voteCount;
+  final List<int> genreIds;
+  final String originalLanguage;
   bool isFavorite;
 
   Movie({
@@ -18,7 +22,11 @@ class Movie with ChangeNotifier {
     required this.backdropPath,
     required this.voteAverage,
     required this.releaseDate,
-    required this.isFavorite
+    required this.isFavorite,
+    required this.popularity,
+    required this.voteCount,
+    required this.genreIds,
+    required this.originalLanguage
   });
 
   void toggleFavorite() {

--- a/lib/core/domain/repositories/movie_repository.dart
+++ b/lib/core/domain/repositories/movie_repository.dart
@@ -8,4 +8,5 @@ abstract class MovieRepository {
   Future<List<Movie>> getFavorites(MovieParams params);
   Future<void> insertFavorite(int movieId);
   Future<void> deleteFavorite(int movieId);
+  Future<Movie> getMovieById(int movieId);
 }

--- a/lib/features/home/presentation/pages/home_page.dart
+++ b/lib/features/home/presentation/pages/home_page.dart
@@ -5,6 +5,9 @@ import 'package:flutter_movies/core/blocs/states/movie_state.dart';
 import 'package:flutter_movies/core/domain/entities/movie.dart';
 import 'package:flutter_movies/features/home/presentation/blocs/events/favorite_events.dart';
 import 'package:flutter_movies/features/home/presentation/blocs/home_movies_bloc.dart';
+import 'package:flutter_movies/features/movie_detail/blocs/get_movie_detail_bloc.dart';
+import 'package:flutter_movies/features/movie_detail/blocs/states/movie_detail_states.dart';
+import 'package:flutter_movies/features/movie_detail/presentation/pages/movie_detail_page.dart';
 import 'package:flutter_movies/l10n/app_localizations.dart';
 import 'package:get_it/get_it.dart';
 
@@ -60,8 +63,15 @@ class _PopularMoviesPageState extends StatelessWidget {
                     padding: const EdgeInsets.only(right: 20.0),
                     child: const Icon(Icons.delete, color: Colors.white), // Icono de eliminar
                   ),
-                  child: FavoriteMovieListItem(
-                    movie: movie,
+                  child: GestureDetector(
+                    onTap: () {
+                      Navigator.push(context, MaterialPageRoute(
+                        builder: (context) => DetailPage(movieId: movie.id)
+                      ));
+                    },
+                    child: FavoriteMovieListItem(
+                      movie: movie
+                    ),
                   ),
                 );
               },

--- a/lib/features/movie_detail/blocs/events/movie_detail_events.dart
+++ b/lib/features/movie_detail/blocs/events/movie_detail_events.dart
@@ -1,0 +1,14 @@
+import 'dart:ffi';
+
+import 'package:equatable/equatable.dart';
+
+abstract class MovieDetailEvent extends Equatable {
+  @override
+  List<Object> get props => [];
+}
+
+class LoadMovieDetail extends MovieDetailEvent {
+  final int movieId;
+
+  LoadMovieDetail({required this.movieId});
+}

--- a/lib/features/movie_detail/blocs/get_movie_detail_bloc.dart
+++ b/lib/features/movie_detail/blocs/get_movie_detail_bloc.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_movies/features/movie_detail/blocs/events/movie_detail_events.dart';
+import 'package:flutter_movies/features/movie_detail/blocs/states/movie_detail_states.dart';
+import 'package:flutter_movies/features/movie_detail/domain/usecases/get_movie_detail_usecase.dart';
+
+class GetMovieDetailBloc extends Bloc<MovieDetailEvent, MovieDetailState> {
+  final GetMovieDetailUsecase getMovieDetailUsecase;
+
+  GetMovieDetailBloc({required this.getMovieDetailUsecase}): super(MovieDetailInitial()) {
+    on<LoadMovieDetail>((event, emit) async {
+      emit(MovieDetailLoading());
+      final result = await getMovieDetailUsecase(event.movieId);
+      emit(MovieDetailLoaded(movie: result));
+    });
+  }
+}

--- a/lib/features/movie_detail/blocs/states/movie_detail_states.dart
+++ b/lib/features/movie_detail/blocs/states/movie_detail_states.dart
@@ -1,0 +1,20 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_movies/core/domain/entities/movie.dart';
+
+abstract class MovieDetailState extends Equatable {
+  @override
+  List<Object> get props => [];
+}
+
+class MovieDetailInitial extends MovieDetailState {}
+
+class MovieDetailLoading extends MovieDetailState {}
+
+class MovieDetailLoaded extends MovieDetailState {
+  final Movie movie;
+
+  MovieDetailLoaded({required this.movie});
+
+  @override
+  List<Object> get props => [movie];
+}

--- a/lib/features/movie_detail/di/injection.dart
+++ b/lib/features/movie_detail/di/injection.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_movies/core/di/injection.dart';
+import 'package:flutter_movies/features/movie_detail/blocs/get_movie_detail_bloc.dart';
+import 'package:flutter_movies/features/movie_detail/domain/usecases/get_movie_detail_usecase.dart';
+import 'package:flutter_movies/features/movie_detail/presentation/usecases/get_movie_detail_usecase_impl.dart';
+
+void setupMovieDetailInjection() {
+  // Registrar Use Case
+  sl.registerLazySingleton<GetMovieDetailUsecase>(
+    () => GetMovieDetailUsecaseImpl(repository: sl()),
+  );
+
+  sl.registerFactory(() => GetMovieDetailBloc(
+    getMovieDetailUsecase: sl(),
+  ));
+}

--- a/lib/features/movie_detail/domain/usecases/get_movie_detail_usecase.dart
+++ b/lib/features/movie_detail/domain/usecases/get_movie_detail_usecase.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_movies/core/domain/entities/movie.dart';
+
+abstract class GetMovieDetailUsecase {
+  Future<Movie> call(int movieId);
+}

--- a/lib/features/movie_detail/presentation/pages/movie_detail_page.dart
+++ b/lib/features/movie_detail/presentation/pages/movie_detail_page.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_movies/features/movie_detail/blocs/events/movie_detail_events.dart';
+import 'package:flutter_movies/features/movie_detail/blocs/get_movie_detail_bloc.dart';
+import 'package:flutter_movies/features/movie_detail/blocs/states/movie_detail_states.dart';
+import 'package:get_it/get_it.dart';
+
+class DetailPage extends StatelessWidget {
+  final int movieId;
+
+  const DetailPage({super.key, required this.movieId});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => GetIt.I<GetMovieDetailBloc>(),
+      child: _MovieDetailPage(movieId: movieId),
+    );
+  }
+}
+
+class _MovieDetailPage extends StatelessWidget {
+
+  final int movieId;
+
+  const _MovieDetailPage({required this.movieId});
+
+  @override
+  Widget build(BuildContext context) {
+
+    // Disparar el evento LoadMovies cuando el widget se construya
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      BlocProvider.of<GetMovieDetailBloc>(context).add(LoadMovieDetail(movieId: movieId));
+    });
+
+    return BlocBuilder<GetMovieDetailBloc, MovieDetailState>(
+      builder: (context, state) {
+        if (state is MovieDetailLoading) {
+          return Scaffold(
+            appBar: AppBar(
+              title: const Text(''),
+            ),
+            body: const Center(
+              child: CircularProgressIndicator(),
+            ),
+          );
+        }
+        else if (state is MovieDetailLoaded) {
+          final movie = state.movie;
+          return Scaffold(
+            appBar: AppBar(
+              title: Text(movie.title),
+            ),
+            body: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (movie.backdropPath.isNotEmpty)
+                    Image.network(
+                      'https://image.tmdb.org/t/p/w500${movie.backdropPath}',
+                      fit: BoxFit.cover,
+                      width: double.infinity,
+                      height: 200,
+                      errorBuilder: (context, error, stackTrace) {
+                        return Image.asset(
+                          'assets/images/default_backdrop.jpg',
+                          fit: BoxFit.cover,
+                          width: double.infinity,
+                          height: 200,
+                        );
+                      },
+                    )
+                  else
+                    Image.asset(
+                      'assets/images/default_backdrop.jpg',
+                      fit: BoxFit.cover,
+                      width: double.infinity,
+                      height: 200,
+                    ),
+                  const SizedBox(height: 8),
+                  SizedBox(height: 8),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(
+                      movie.title,
+                      style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  SizedBox(height: 4),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(
+                      'Release Date: ${movie.releaseDate}',
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: Colors.grey[600]),
+                    ),
+                  ),
+                  SizedBox(height: 8),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(
+                      'Genres: ${movie.genreIds.join(', ')}',
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: Colors.grey[600]),
+                    ),
+                  ),
+                  SizedBox(height: 8),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(
+                      'Language: ${movie.originalLanguage}',
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: Colors.grey[600]),
+                    ),
+                  ),
+                  SizedBox(height: 16),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(
+                      movie.overview,
+                      style: Theme.of(context).textTheme.bodyMedium,
+                      textAlign: TextAlign.justify,
+                    ),
+                  ),
+                  SizedBox(height: 16),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Row(
+                      children: [
+                        Icon(Icons.star, color: Colors.yellow[700]),
+                        SizedBox(width: 4),
+                        Text(
+                          '${movie.voteAverage} / 10 (${movie.voteCount} votes)',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ],
+                    ),
+                  ),
+                  SizedBox(height: 16),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Row(
+                      children: [
+                        Text(
+                          'Popularity: ${movie.popularity.toStringAsFixed(1)}',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        } else {
+          return Scaffold(
+            appBar: AppBar(
+              title: const Text(''),
+            ),
+            body: const Center(
+              child: Text(''),
+            ),
+          );
+        }
+      },
+    );
+  }
+}

--- a/lib/features/movie_detail/presentation/usecases/get_movie_detail_usecase_impl.dart
+++ b/lib/features/movie_detail/presentation/usecases/get_movie_detail_usecase_impl.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_movies/core/domain/entities/movie.dart';
+import 'package:flutter_movies/core/domain/repositories/movie_repository.dart';
+import 'package:flutter_movies/features/movie_detail/domain/usecases/get_movie_detail_usecase.dart';
+
+class GetMovieDetailUsecaseImpl implements GetMovieDetailUsecase {
+  final MovieRepository repository;
+
+  GetMovieDetailUsecaseImpl({required this.repository});
+
+  @override
+  Future<Movie> call(int movieId) {
+    return repository.getMovieById(movieId);
+  }
+
+}

--- a/lib/features/now_playing/presentation/pages/now_playing_page.dart
+++ b/lib/features/now_playing/presentation/pages/now_playing_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_movies/core/blocs/events/movie_event.dart';
 import 'package:flutter_movies/core/blocs/states/movie_state.dart';
 import 'package:flutter_movies/core/widgets/movie_list_item.dart';
+import 'package:flutter_movies/features/movie_detail/presentation/pages/movie_detail_page.dart';
 import 'package:flutter_movies/features/now_playing/presentation/blocs/now_playing_movies_bloc.dart';
 import 'package:flutter_movies/l10n/app_localizations.dart';
 import 'package:get_it/get_it.dart';
@@ -44,12 +45,19 @@ class _PopularMoviesPageState extends StatelessWidget {
                 final movie = state.movies[index];
                 return ChangeNotifierProvider.value(
                   value: movie,
-                  child: MovieListItem(
-                    movie: movie,
-                    onFavoritePressed: () {
-                      BlocProvider.of<NowPlayingMoviesBloc>(context).add(ToggleFavorite(movieId: movie.id));
+                  child: GestureDetector(
+                    onTap: () {
+                      Navigator.push(context, MaterialPageRoute(
+                        builder: (context) => DetailPage(movieId: movie.id)
+                      ));
                     },
-                  )
+                    child: MovieListItem(
+                      movie: movie,
+                      onFavoritePressed: () {
+                        BlocProvider.of<NowPlayingMoviesBloc>(context).add(ToggleFavorite(movieId: movie.id));
+                      },
+                    ),
+                  ),
                 );
               },
             );

--- a/lib/features/popular_movies/presentation/pages/popular_movies_page.dart
+++ b/lib/features/popular_movies/presentation/pages/popular_movies_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_movies/core/blocs/events/movie_event.dart';
 import 'package:flutter_movies/core/blocs/states/movie_state.dart';
 import 'package:flutter_movies/core/widgets/movie_list_item.dart';
+import 'package:flutter_movies/features/movie_detail/presentation/pages/movie_detail_page.dart';
 import 'package:flutter_movies/features/popular_movies/presentation/blocs/popular_movie_bloc.dart';
 import 'package:flutter_movies/l10n/app_localizations.dart';
 import 'package:get_it/get_it.dart';
@@ -46,12 +47,19 @@ class _PopularMoviesPageState extends StatelessWidget {
                 final movie = state.movies[index];
                 return ChangeNotifierProvider.value(
                   value: movie,
-                  child: MovieListItem(
-                    movie: movie,
-                    onFavoritePressed: () {
-                      BlocProvider.of<PopularMovieBloc>(context).add(ToggleFavorite(movieId: movie.id));
+                  child: GestureDetector(
+                    onTap: () {
+                      Navigator.push(context, MaterialPageRoute(
+                        builder: (context) => DetailPage(movieId: movie.id)
+                      ));
                     },
-                  )
+                    child: MovieListItem(
+                      movie: movie,
+                      onFavoritePressed: () {
+                        BlocProvider.of<PopularMovieBloc>(context).add(ToggleFavorite(movieId: movie.id));
+                      },
+                    ),
+                  ),
                 );
               },
             );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,8 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_movies/core/di/injection.dart';
 import 'package:flutter_movies/features/home/di/injection.dart';
 import 'package:flutter_movies/features/home/presentation/pages/home_page.dart';
+import 'package:flutter_movies/features/movie_detail/di/injection.dart';
+import 'package:flutter_movies/features/movie_detail/presentation/pages/movie_detail_page.dart';
 import 'package:flutter_movies/features/now_playing/di/injection.dart';
 import 'package:flutter_movies/features/settings/di/injection.dart';
 import 'package:flutter_movies/features/settings/presentation/blocs/notifier/language_notifier.dart';
@@ -30,6 +32,7 @@ void main() async {
   setupPopularMoviesInjection();
   setupNowPopularMoviesInjection();
   setupSettingsInjection();
+  setupMovieDetailInjection();
   runApp(MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => GetIt.I<ThemeNotifier>()),
@@ -94,10 +97,11 @@ class _MainPageState extends State<MainPage> {
   int _currentIndex = 0;
 
   final List<Widget> _pages = [
-    HomePage(),
+    const HomePage(),
     const PopularMoviesPage(),
-    NowPlayingPage(),
-    SettingsPage(),
+    const NowPlayingPage(),
+    const SettingsPage(),
+    const DetailPage(movieId: 0)
   ];
 
   void _onItemTapped(int index) {


### PR DESCRIPTION
## Objective
- Implement feature movie detail

## Summary
- Added a new feature to visualize movie details.
- Updated `MovieLocalDataSource` to support fetching movie details.
- Modified `MovieRepository` to include a method for retrieving movie details.
- Updated the page to include a new detail screen.
- Added `MovieDetailBloc` to handle state management for the movie detail view.
- Implemented `GetMovieDetailUsecase` to interact with the repository.
b02f0d4


## Visuales
<img src="https://github.com/user-attachments/assets/dbbaa157-b146-43f3-87dc-2175c13b8440" alt=" dark" width="200"/>